### PR TITLE
Add support for private ips and bastion access to AWS instances

### DIFF
--- a/terraform.py
+++ b/terraform.py
@@ -407,6 +407,8 @@ def aws_host(resource, module_name):
         attrs['ansible_ssh_user'] = raw_attrs['tags.sshUser']
     if 'tags.sshPrivateIp' in raw_attrs:
         attrs['ansible_ssh_host'] = raw_attrs['private_ip']
+    if not attrs['ansible_ssh_host']:
+        attrs['ansible_ssh_host'] = raw_attrs['private_ip']
 
     # attrs specific to Mantl
     attrs.update({

--- a/terraform.py
+++ b/terraform.py
@@ -409,6 +409,8 @@ def aws_host(resource, module_name):
         attrs['ansible_ssh_host'] = raw_attrs['private_ip']
     if not attrs['ansible_ssh_host']:
         attrs['ansible_ssh_host'] = raw_attrs['private_ip']
+    if 'tags.sshCommonArgs' in raw_attrs and raw_attrs['tags.sshCommonArgs']:
+        attrs['ansible_ssh_common_args'] = raw_attrs['tags.sshCommonArgs']
 
     # attrs specific to Mantl
     attrs.update({


### PR DESCRIPTION
This PR has two changes, isolated to AWS only:
1. When an instance does not have a public ip ensure the attribute `ansible_ssh_host` has a value by defaulting it to `private_ip`. Tagging an instance with `sshPrivateIp` achieves the same effect in the current script however adding this tag may not be convenient because it is difficult to conditionally add a tag to an instance in terraform.
2. Users can choose to tag their instance with `sshCommonArgs` which is passed to ansible and appended to ssh commands used during provisioning. This is commonly used to use a bastion/jump host for accessing private instances. [Docs](http://docs.ansible.com/ansible/faq.html#how-do-i-configure-a-jump-host-to-access-servers-that-i-have-no-direct-access-to). By exposing this configuration as a tag on a per instance bases this allows users to use different bastion hosts per instance if needed. 

**NOTE: `ansible_ssh_common_args` is not supported in Ansible < 2.0. Mantl does not yet work with Ansible 2.0.** I included this commit in the event someone uses this inventory script outside of Mantl and would like to take advantage of ssh options. Let me know if this change is better off left out until Mantl supports 2.0.  
