### PR TITLE
Fix error when booting openstack VM from volume

### DIFF
--- a/terraform.py
+++ b/terraform.py
@@ -351,7 +351,8 @@ def openstack_host(resource, module_name):
     })
 
     # add groups based on attrs
-    groups.append('os_image=' + attrs['image']['name'])
+    if 'name' in attrs['image'].keys():
+        groups.append('os_image=' + attrs['image']['name'])
     groups.append('os_flavor=' + attrs['flavor']['name'])
     groups.extend('os_metadata_%s=%s' % item
                   for item in attrs['metadata'].items())


### PR DESCRIPTION
When booting Openstack VMs from a volume (instead of an image) terraform.py breaks because it is expecting an image name attribute to configure groups

```
Traceback (most recent call last):
  File "inventory/terraform/terraform.py", line 764, in <module>
    main()
  File "inventory/terraform/terraform.py", line 749, in main
    output = query_list(hosts)
  File "inventory/terraform/terraform.py", line 691, in query_list
    for name, attrs, hostgroups in hosts:
  File "inventory/terraform/terraform.py", line 67, in iterhosts
    yield parser(resource, module_name)
  File "inventory/terraform/terraform.py", line 83, in inner
    name, attrs, groups = func(*args, **kwargs)
  File "inventory/terraform/terraform.py", line 354, in openstack_host
    groups.append('os_image=' + attrs['image']['name'])
KeyError: u'name'
```

This proposed fix ensures the attribute exists before adding it to the groups list.
