### PR TITLE
Remove default ssh port

### DIFF
--- a/terraform.py
+++ b/terraform.py
@@ -573,6 +573,10 @@ def azure_host(resource, module_name):
         'ansible_ssh_user': raw_attrs['username'],
         'ansible_ssh_host': raw_attrs['vip_address'],
     }
+    
+    for ep in attrs['endpoint']:
+        if ep['name'] == 'SSH':
+            attrs['ansible_ssh_port'] = int(ep['public_port'])
 
     # attrs specific to mantl
     attrs.update({

--- a/terraform.py
+++ b/terraform.py
@@ -166,7 +166,6 @@ def triton_machine(resource, module_name):
 
         # ansible
         'ansible_ssh_host': raw_attrs['primaryip'],
-        'ansible_ssh_port': 22,
         'ansible_ssh_user': 'root',  # it's "root" on Triton by default
 
         # generic
@@ -226,7 +225,6 @@ def digitalocean_host(resource, tfvars=None):
         'status': raw_attrs['status'],
         # ansible
         'ansible_ssh_host': raw_attrs['ipv4_address'],
-        'ansible_ssh_port': 22,
         'ansible_ssh_user': 'root',  # it's always "root" on DO
         # generic
         'public_ipv4': raw_attrs['ipv4_address'],
@@ -277,7 +275,6 @@ def softlayer_host(resource, module_name):
         'public_ipv4': raw_attrs['ipv4_address'],
         'private_ipv4': raw_attrs['ipv4_address_private'],
         'ansible_ssh_host': raw_attrs['ipv4_address'],
-        'ansible_ssh_port': 22,
         'ansible_ssh_user': 'root',
         'provider': 'softlayer',
     }
@@ -317,7 +314,6 @@ def openstack_host(resource, module_name):
         'region': raw_attrs.get('region', ''),
         'security_groups': parse_list(raw_attrs, 'security_groups'),
         # ansible
-        'ansible_ssh_port': 22,
         # workaround for an OpenStack bug where hosts have a different domain
         # after they're restarted
         'host_domain': 'novalocal',
@@ -394,7 +390,6 @@ def aws_host(resource, module_name):
         'vpc_security_group_ids': parse_list(raw_attrs,
                                              'vpc_security_group_ids'),
         # ansible-specific
-        'ansible_ssh_port': 22,
         'ansible_ssh_host': raw_attrs['public_ip'],
         # generic
         'public_ipv4': raw_attrs['public_ip'],
@@ -462,7 +457,6 @@ def gce_host(resource, module_name):
         'tags': parse_list(raw_attrs, 'tags'),
         'zone': raw_attrs['zone'],
         # ansible
-        'ansible_ssh_port': 22,
         'provider': 'gce',
     }
 
@@ -524,7 +518,6 @@ def vsphere_host(resource, module_name):
         'private_ipv4': ip_address,
         'public_ipv4': ip_address,
         'metadata': parse_dict(raw_attrs, 'custom_configuration_parameters'),
-        'ansible_ssh_port': 22,
         'provider': 'vsphere',
     }
 
@@ -577,7 +570,6 @@ def azure_host(resource, module_name):
         'virtual_network': raw_attrs['virtual_network'],
         'endpoint': parse_attr_list(raw_attrs, 'endpoint'),
         # ansible
-        'ansible_ssh_port': 22,
         'ansible_ssh_user': raw_attrs['username'],
         'ansible_ssh_host': raw_attrs['vip_address'],
     }
@@ -610,11 +602,13 @@ def clc_server(resource, module_name):
     md = parse_dict(raw_attrs, 'metadata')
     attrs = {
         'metadata': md,
-        'ansible_ssh_port': md.get('ssh_port', 22),
         'ansible_ssh_user': md.get('ssh_user', 'root'),
         'provider': 'clc',
         'publicly_routable': False,
     }
+    
+    if 'ssh_port' in md:
+        attrs['ansible_ssh_port'] = md.get('ssh_port')
 
     try:
         attrs.update({

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -87,7 +87,6 @@ def test_name(aws_resource, aws_host):
     'vpc_security_group_ids': ['sg-9c360cf8', 'sg-9d360cf9'],
     # ansible
     'ansible_ssh_host': '52.7.74.115',
-    'ansible_ssh_port': 22,
     'ansible_ssh_user': 'ec2-user',
     # mi
     'consul_dc': 'aws',

--- a/tests/test_clc.py
+++ b/tests/test_clc.py
@@ -46,7 +46,6 @@ def test_name(clc_resource, clc_server):
         'role':'control',
         'dc': 'CA1'
     },
-    'ansible_ssh_port': 22,
     'ansible_ssh_user': 'root',
     'ansible_ssh_host': '10.50.100.13',
     'private_ipv4': '10.50.100.13',

--- a/tests/test_digitalocean.py
+++ b/tests/test_digitalocean.py
@@ -40,7 +40,6 @@ def test_name(digitalocean_resource, digitalocean_host):
     'status': 'active',
     # ansible
     'ansible_ssh_host': '1.2.3.4',
-    'ansible_ssh_port': 22,
     'ansible_ssh_user': 'root',
     # generic
     'public_ipv4': '1.2.3.4',

--- a/tests/test_gce.py
+++ b/tests/test_gce.py
@@ -90,7 +90,6 @@ def test_name(gce_resource, gce_host):
     'zone': 'us-central1-a',
     # ansible
     'ansible_ssh_host': '104.197.63.156',
-    'ansible_ssh_port': 22,
     # mi
     'consul_dc': 'gce-dc',
     'role': 'control',

--- a/tests/test_openstack.py
+++ b/tests/test_openstack.py
@@ -71,7 +71,6 @@ def test_name(openstack_resource, openstack_host):
     'region': 'eu-amsterdam-1',
     'security_groups': ['default'],
     # ansible
-    'ansible_ssh_port': 22,
     'ansible_ssh_host': '173.39.243.27',
     'publicly_routable': True,
     # mi

--- a/tests/test_softlayer.py
+++ b/tests/test_softlayer.py
@@ -45,7 +45,6 @@ def test_name(softlayer_resource, softlayer_host):
     'ssh_keys': ['23456'],
     # ansible
     'ansible_ssh_host': '1.2.3.4',
-    'ansible_ssh_port': 22,
     'ansible_ssh_user': 'root',
     # generic
     'public_ipv4': '1.2.3.4',

--- a/tests/test_triton.py
+++ b/tests/test_triton.py
@@ -69,7 +69,6 @@ def test_name(triton_resource, triton_machine):
     'user_script': '',
     # ansible
     'ansible_ssh_host': '165.225.136.36',
-    'ansible_ssh_port': 22,
     'ansible_ssh_user': 'root',
     # generic
     'public_ipv4': '165.225.136.36',

--- a/tests/test_vsphere.py
+++ b/tests/test_vsphere.py
@@ -50,7 +50,6 @@ def test_name(vsphere_resource, vsphere_host):
     'id': 'server01',
     # ansible
     'ansible_ssh_host': '1.2.3.4',
-    'ansible_ssh_port': 22,
     'ansible_ssh_user': 'vsphere-user',
     'ansible_python_interpreter': '/usr/bin/python',
     # generic


### PR DESCRIPTION
- It's the default anyways, and prevents users from overriding it (specifically windows users)
- Fixes #50