### PR TITLE
Remove default ssh port

### DIFF
--- a/src/ati/terraform.py
+++ b/src/ati/terraform.py
@@ -206,7 +206,6 @@ def ddcloud_server(resource, module_name):
 
         # ansible
         'ansible_ssh_host': raw_attrs['public_ipv4'],
-        'ansible_ssh_port': 22,
         'ansible_ssh_user': 'root',  # it's always "root" on CloudControl images
 
         # generic
@@ -327,7 +326,6 @@ def packet_device(resource, tfvars=None):
         'state': raw_attrs['state'],
         # ansible
         'ansible_ssh_host': raw_attrs['network.0.address'],
-        'ansible_ssh_port': 22,
         'ansible_ssh_user': 'root',  # it's always "root" on Packet
         # generic
         'ipv4_address': raw_attrs['network.0.address'],
@@ -562,7 +560,6 @@ def aws_host(resource, module_name, **kwargs):
         'vpc_security_group_ids': parse_list(raw_attrs,
                                              'vpc_security_group_ids'),
         # ansible-specific
-        'ansible_ssh_port': 22,
         'ansible_ssh_host': raw_attrs[ssh_host_key],
         # generic
         'public_ipv4': raw_attrs['public_ip'],
@@ -743,7 +740,6 @@ def azurerm_host(resource, module_name):
         'id': raw_attrs['id'],
         'name': raw_attrs['name'],
         # ansible
-        'ansible_ssh_port': 22,
         'ansible_ssh_user': raw_attrs.get('tags.ssh_user', ''),
         'ansible_ssh_host': raw_attrs.get('tags.ssh_ip', ''),
     }
@@ -904,7 +900,6 @@ def scaleway_host(resource, tfvars=None):
         'type': raw_attrs['type'],
         # ansible
         'ansible_ssh_host': raw_attrs['public_ip'],
-        'ansible_ssh_port': 22,
         'ansible_ssh_user': 'root',  # it's always "root" on DO
         # generic
         'public_ipv4': raw_attrs['public_ip'],

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -87,7 +87,6 @@ def test_name(aws_resource, aws_host):
     'vpc_security_group_ids': ['sg-9c360cf8', 'sg-9d360cf9'],
     # ansible
     'ansible_ssh_host': '52.7.74.115',
-    'ansible_ssh_port': 22,
     'ansible_ssh_user': 'ec2-user',
     # mi
     'consul_dc': 'aws',

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -60,7 +60,6 @@ def test_name(azure_resource, azure_host):
     'image': 'apollo-ubuntu-14.04-amd64-1444419199',
     'ssh_key_thumbprint': '156E660861DBED413BE0F9E617FF7D720E019943',
     'consul_dc': 'north-europe',
-    'ansible_ssh_port': 22,
     'ip_address': '10.0.0.5',
     'id': 'mi-control-01',
     'size': 'Medium',

--- a/tests/test_azurerm.py
+++ b/tests/test_azurerm.py
@@ -70,7 +70,6 @@ def test_name(azurerm_resource, azurerm_host):
 @pytest.mark.parametrize('attr,should', {
         "id": "/subscriptions/mysubguid/resourceGroups/terraformdemo/providers/Microsoft.Compute/virtualMachines/terraformdemo",
         "name": "terraformdemo",
-        "ansible_ssh_port": 22,
         "ansible_ssh_user": "terraformdemoadmin",
         "ansible_ssh_host": "10.10.0.1",
 }.items())

--- a/tests/test_ddcloud.py
+++ b/tests/test_ddcloud.py
@@ -71,7 +71,6 @@ def test_name(ddcloud_resource, ddcloud_server):
     'image_name': 'CentOS 7 64-bit 2 CPU',
     
     'ansible_ssh_host': '168.128.37.189',
-    'ansible_ssh_port': 22,
     'ansible_ssh_user': 'root',
 
     'private_ipv4': '10.5.50.25',

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -72,7 +72,6 @@ def test_name(packet_resource, packet_device):
     'project_id': "573b1856-b214-43fb-9282-314d57e99eb7",
     'state': 'active',
     'ansible_ssh_host': "147.75.100.215",
-    'ansible_ssh_port': 22,
     'ansible_ssh_user': 'root',
     'ipv4_address': "147.75.100.215",
     'public_ipv4': "147.75.100.215",

--- a/tests/test_scaleway.py
+++ b/tests/test_scaleway.py
@@ -58,7 +58,6 @@ def test_name(scaleway_resource, scaleway_host):
     'type': 'VC1M',
     # ansible
     'ansible_ssh_host': '77.77.77.77',
-    'ansible_ssh_port': 22,
     'ansible_ssh_user': 'root',
     # generic
     'private_ipv4': '55.55.55.55',


### PR DESCRIPTION
- Its the default anyways, and prevents users from overriding it (such
as Windows users)
- Fixes #50 (again)