### PR TITLE
Update unicode keywords for python3

### DIFF
--- a/src/ati/terraform.py
+++ b/src/ati/terraform.py
@@ -52,11 +52,11 @@ def iter_states(root=None):
 
 def iterresources(sources):
     for source in sources:
-	if type(source) in [unicode, str]:
+        if type(source) in [str, bytes]:
             with open(source, 'r') as json_file:
                 state = json.load(json_file)
-	else:
-	    state = source
+        else:
+            state = source
         for module in state['modules']:
             name = module['path'][-1]
             for key, resource in list(module['resources'].items()):


### PR DESCRIPTION
* Also fix issue around "inconsistent use of tabs and spaces"

Testing:
* Ran py.test, but ran into https://github.com/pytest-dev/pytest/issues/2455
* Was able to get the tests to run by `s/--strict/-W error/` in setup.cfg as mentioned in the comments on that issue.
* There's still errors in the tests that were there before this patch.

Pre-patch test run:

```
========================================================== FAILURES ==========================================================
_______________________________________________________ pyflakes-check _______________________________________________________
/home/anross/Github/anross/terraform.py/src/ati/terraform.py:55: inconsistent use of tabs and spaces in indentation
	if type(source) in [unicode, str]:
                                   ^
________________________________________________________ mccabe-check ________________________________________________________
/home/anross/Github/anross/terraform.py/src/ati/terraform.py:55: inconsistent use of tabs and spaces in indentation
	if type(source) in [unicode, str]:
                                   ^
====================================================== warnings summary ======================================================
None
  [pytest] section in setup.cfg files is deprecated, use [tool:pytest] instead.

-- Docs: http://doc.pytest.org/en/latest/warnings.html
================================ 2 failed, 348 passed, 23 skipped, 1 warnings in 1.22 seconds ================================
```

Post patch:
```========================================================== FAILURES ==========================================================
_______________________________________________________ pyflakes-check _______________________________________________________
/home/aross/Github/anross/terraform.py/src/ati/terraform.py:55: UndefinedName
undefined name 'unicode'
__________________________________________________ test_attrs[tags-should3] __________________________________________________

scaleway_resource = {'depends_on': ['data.scaleway_image.ubuntu'], 'primary': {'attributes': {'enable_ipv6': 'false', 'id': 'a982f5e3-5ad4...424de25fe84', 'name': 'test-server-01', ...}, 'id': 'a982f5e3-5ad4-4c01-b4bf-f47a7b834e43'}, 'type': 'scaleway_server'}
scaleway_host = <function scaleway_host at 0x7f152929dae8>, attr = 'tags', should = ['dev', 'frontend', 'lga']

    @pytest.mark.parametrize('attr,should', {
        'enable_ipv6': 'false',
        'id': 'a982f5e3-5ad4-4c01-b4bf-f47a7b834e43',
        'image': '7258ac9b-61e7-4f69-a72d-b424de25fe84',
        'name': 'test-server-01',
        'private_ip': '55.55.55.55',
        'public_ip': '77.77.77.77',
        'state': 'running',
        'state_detail': 'booted',
        'tags': ['dev', 'frontend', 'lga'],
        'type': 'VC1M',
        # ansible
        'ansible_ssh_host': '77.77.77.77',
        'ansible_ssh_user': 'root',
        # generic
        'private_ipv4': '55.55.55.55',
        'public_ipv4': '77.77.77.77',
        'provider': 'scaleway',
    }.items())
    def test_attrs(scaleway_resource, scaleway_host, attr, should):
        _, attrs, _ = scaleway_host(scaleway_resource, 'module_name')
        assert attr in attrs
>       assert attrs[attr] == should
E       AssertionError: assert ['lga', 'dev', 'frontend'] == ['dev', 'frontend', 'lga']
E         At index 0 diff: 'lga' != 'dev'
E         Use -v to get the full diff

tests/test_scaleway.py:70: AssertionError
====================================================== warnings summary ======================================================
None
  [pytest] section in setup.cfg files is deprecated, use [tool:pytest] instead.

-- Docs: http://doc.pytest.org/en/latest/warnings.html
================================ 2 failed, 348 passed, 23 skipped, 1 warnings in 1.32 seconds ================================```