### PR TITLE
Sanitize group names to keep compatibility with ansible static inventories  in the future

### DIFF
--- a/src/ati/terraform.py
+++ b/src/ati/terraform.py
@@ -100,6 +100,9 @@ def _clean_dc(dcname):
     # ensure that the consul_dc attribute meets these requirements.
     return re.sub('[^\w_\-]', '-', dcname)
 
+def _clean_ansible(name):
+    # ansible 2.4+ group names for non-dynamic inventories are alphanumeric or _
+    return re.sub('[^\w_]', '_', name)
 
 def iterhosts(resources, args):
     '''yield host tuples of (name, attributes, groups)'''
@@ -137,6 +140,9 @@ def calculate_mantl_vars(func):
         # groups
         if attrs.get('publicly_routable', False):
             groups.append('publicly_routable')
+
+        # sanitize ansible group names
+        groups = [_clean_ansible(g) for g in groups]
 
         return name, attrs, groups
 

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -106,12 +106,12 @@ def test_attrs(aws_resource, aws_host, attr, should):
 
 @pytest.mark.parametrize(
     'group',
-    ['aws_ami=ami-fe100a96', 'aws_az=us-east-1e', 'aws_key_name=key-mi',
-     'aws_tenancy=default', 'aws_tag_sshUser=ec2-user', 'aws_tag_role=control',
-     'aws_tag_dc=aws', 'aws_tag_Name=mi-control-01',
-     'aws_vpc_security_group=sg-9c360cf8',
-     'aws_vpc_security_group=sg-9d360cf9', 'aws_subnet_id=subnet-1155c03a',
-     'role=control', 'dc=aws'])
+    ['aws_ami_ami_fe100a96', 'aws_az_us_east_1e', 'aws_key_name_key_mi',
+     'aws_tenancy_default', 'aws_tag_sshUser_ec2_user', 'aws_tag_role_control',
+     'aws_tag_dc_aws', 'aws_tag_Name_mi_control_01',
+     'aws_vpc_security_group_sg_9c360cf8',
+     'aws_vpc_security_group_sg_9d360cf9', 'aws_subnet_id_subnet_1155c03a',
+     'role_control', 'dc_aws'])
 def test_groups(aws_resource, aws_host, group):
     _, _, groups = aws_host(aws_resource, 'module_name')
     assert group in groups

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -91,13 +91,13 @@ def test_attrs(azure_resource, azure_host, attr, should):
 
 
 @pytest.mark.parametrize('group', [
-    'azure_username=ubuntu',
-    'dc=north-europe',
-    'azure_location=north-europe',
-    'azure_image=apollo-ubuntu-14.04-amd64-1444419199',
-    'role=mesos_masters',
-    'azure_security_group=default-apollo-mesos',
-    'role=mesos_masters'
+    'azure_username_ubuntu',
+    'dc_north_europe',
+    'azure_location_north_europe',
+    'azure_image_apollo_ubuntu_14_04_amd64_1444419199',
+    'role_mesos_masters',
+    'azure_security_group_default_apollo_mesos',
+    'role_mesos_masters'
 ])
 def test_groups(azure_resource, azure_host, group):
     _, _, groups = azure_host(azure_resource, 'North_Europe')

--- a/tests/test_azurerm.py
+++ b/tests/test_azurerm.py
@@ -80,7 +80,7 @@ def test_attrs(azurerm_resource, azurerm_host, attr, should):
 
 
 @pytest.mark.parametrize('group', [
-        'role=myrole'
+        'role_myrole'
 ])
 def test_groups(azurerm_resource, azurerm_host, group):
     _, _, groups = azurerm_host(azurerm_resource, 'ukwest')

--- a/tests/test_clc.py
+++ b/tests/test_clc.py
@@ -61,8 +61,8 @@ def test_attrs(clc_resource, clc_server, attr, should):
 
 
 @pytest.mark.parametrize('group', [
-    'role=control',
-    'dc=CA1'
+    'role_control',
+    'dc_CA1'
 ])
 def test_groups(clc_resource, clc_server, group):
     _, _, groups = clc_server(clc_resource, 'CA1')

--- a/tests/test_ddcloud.py
+++ b/tests/test_ddcloud.py
@@ -85,8 +85,8 @@ def test_attrs(ddcloud_resource, ddcloud_server, attr, should):
 
 
 @pytest.mark.parametrize('group', [
-    'role=edge',
-    'dc=au9',
+    'role_edge',
+    'dc_au9',
 ])
 def test_groups(ddcloud_resource, ddcloud_server, group):
     _, _, groups = ddcloud_server(ddcloud_resource, 'module_name')

--- a/tests/test_digitalocean.py
+++ b/tests/test_digitalocean.py
@@ -58,9 +58,9 @@ def test_attrs(digitalocean_resource, digitalocean_host, attr, should):
 
 
 @pytest.mark.parametrize(
-    'group', ['do_image=centos-7-0-x64', 'do_locked=False', 'do_region=nyc3',
-              'do_size=4gb', 'do_status=active', 'do_metadata_role=control',
-              'do_tag=test_tag', 'role=control', 'dc=nyc3']
+    'group', ['do_image_centos_7_0_x64', 'do_locked_False', 'do_region_nyc3',
+              'do_size_4gb', 'do_status_active', 'do_metadata_role_control',
+              'do_tag_test_tag', 'role_control', 'dc_nyc3']
 )
 def test_groups(digitalocean_resource, digitalocean_host, group):
     _, _, groups = digitalocean_host(digitalocean_resource, 'module_name')

--- a/tests/test_gce.py
+++ b/tests/test_gce.py
@@ -109,15 +109,15 @@ def test_attrs(gce_resource, gce_host, attr, should):
 
 
 @pytest.mark.parametrize('group', [
-    'gce_image=centos-7-v20150423',
-    'gce_machine_type=n1-standard-1',
-    'gce_metadata_dc=gce-dc',
-    'gce_metadata_role=control',
-    'gce_tag=mi',
-    'gce_tag=control',
+    'gce_image_centos_7_v20150423',
+    'gce_machine_type_n1_standard_1',
+    'gce_metadata_dc_gce_dc',
+    'gce_metadata_role_control',
+    'gce_tag_mi',
+    'gce_tag_control',
     'gce_publicly_routable',
-    'role=control',
-    'dc=gce-dc',
+    'role_control',
+    'dc_gce_dc',
 ])
 def test_groups(gce_resource, gce_host, group):
     _, _, groups = gce_host(gce_resource, 'module_name')

--- a/tests/test_openstack.py
+++ b/tests/test_openstack.py
@@ -90,12 +90,12 @@ def test_attrs(openstack_resource, openstack_host, attr, should):
     assert attrs[attr] == should
 
 @pytest.mark.parametrize('group', [
-    'os_image=centos-7_x86_64-2015-01-27-v6',
-    'os_flavor=CO2-2XLarge',
-    'os_metadata_role=control',
-    'os_region=eu-amsterdam-1',
-    'role=control',
-    'dc=module_name',
+    'os_image_centos_7_x86_64_2015_01_27_v6',
+    'os_flavor_CO2_2XLarge',
+    'os_metadata_role_control',
+    'os_region_eu_amsterdam_1',
+    'role_control',
+    'dc_module_name',
 ])
 def test_groups(openstack_resource, openstack_host, group):
     _, _, groups = openstack_host(openstack_resource, 'module_name')

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -89,14 +89,14 @@ def test_attrs(packet_resource, packet_device, attr, should):
 
 
 @pytest.mark.parametrize(
-    'group', ['packet_operating_system=centos_7',
-              'packet_locked=False',
-              'packet_facility=ams1',
-              'packet_plan=baremetal_0',
-              'packet_state=active',
-              'packet_metadata_role=workstation',
-              'role=workstation',
-              'dc=ams1']
+    'group', ['packet_operating_system_centos_7',
+              'packet_locked_False',
+              'packet_facility_ams1',
+              'packet_plan_baremetal_0',
+              'packet_state_active',
+              'packet_metadata_role_workstation',
+              'role_workstation',
+              'dc_ams1']
 )
 def test_groups(packet_resource, packet_device, group):
     _, _, groups = packet_device(packet_resource, 'module_name')

--- a/tests/test_scaleway.py
+++ b/tests/test_scaleway.py
@@ -72,8 +72,8 @@ def test_attrs(scaleway_resource, scaleway_host, attr, should):
 
 @pytest.mark.parametrize(
     'group',
-    ['scaleway_image=7258ac9b-61e7-4f69-a72d-b424de25fe84', 'scaleway_type=VC1M', 'scaleway_state=running',
-     'scaleway_tag=frontend', 'scaleway_tag=dev', 'scaleway_tag=lga'])
+    ['scaleway_image_7258ac9b_61e7_4f69_a72d_b424de25fe84', 'scaleway_type_VC1M', 'scaleway_state_running',
+     'scaleway_tag_frontend', 'scaleway_tag_dev', 'scaleway_tag_lga'])
 def test_groups(scaleway_resource, scaleway_host, group):
     _, _, groups = scaleway_host(scaleway_resource, 'module_name')
     assert group in groups

--- a/tests/test_softlayer.py
+++ b/tests/test_softlayer.py
@@ -61,7 +61,7 @@ def test_attrs(softlayer_resource, softlayer_host, attr, should):
 
 
 @pytest.mark.parametrize(
-    'group', ['dc=mi', 'role=control']
+    'group', ['dc_mi', 'role_control']
 )
 def test_groups(softlayer_resource, softlayer_host, group):
     _, _, groups = softlayer_host(softlayer_resource, 'module_name')

--- a/tests/test_triton.py
+++ b/tests/test_triton.py
@@ -88,12 +88,12 @@ def test_attrs(triton_resource, triton_machine, attr, should):
 
 
 @pytest.mark.parametrize(
-    'group', ['triton_image=dd31507e-031e-11e6-be8a-8f2707b5b3ee',
-              'triton_package=Medium 4GB', 'triton_state=running',
-              'triton_firewall_enabled=False', 'triton_tags_role=control',
-              'triton_network=56f0fd52-4df1-49bd-af0c-81c717ea8bce',
-              'triton_network=65ae3604-7c5c-4255-9c9f-6248e5d78900',
-              'role=control', 'dc=none'],
+    'group', ['triton_image_dd31507e_031e_11e6_be8a_8f2707b5b3ee',
+              'triton_package_Medium_4GB', 'triton_state_running',
+              'triton_firewall_enabled_False', 'triton_tags_role_control',
+              'triton_network_56f0fd52_4df1_49bd_af0c_81c717ea8bce',
+              'triton_network_65ae3604_7c5c_4255_9c9f_6248e5d78900',
+              'role_control', 'dc_none'],
 )
 def test_groups(triton_resource, triton_machine, group):
     _, _, groups = triton_machine(triton_resource, 'module_name')

--- a/tests/test_ucs.py
+++ b/tests/test_ucs.py
@@ -55,8 +55,8 @@ def test_attrs(ucs_resource, ucs_host, attr, should):
     assert attrs[attr] == should
 
 @pytest.mark.parametrize('group', [
-    'role=control',
-    'dc=root',
+    'role_control',
+    'dc_root',
 ])
 def test_groups(ucs_resource, ucs_host, group):
     _, _, groups = ucs_host(ucs_resource, 'root')


### PR DESCRIPTION
- Fixes #79
- Breaks probably just about anyone using this inventory

I don't expect this to be the final merge of this, but (a) I need this now so I don't have to change stuff in the future and (b) this is more intended to get the conversation started about this issue.